### PR TITLE
Change tempmail URL

### DIFF
--- a/lib/temp/mail/client.rb
+++ b/lib/temp/mail/client.rb
@@ -6,13 +6,13 @@ module Temp
   module Mail
     class Client
       def available_domains
-        response = Net::HTTP.get_response(URI('http://api.temp-mail.ru/request/domains/format/json/'))
+        response = Net::HTTP.get_response(URI('https://api.temp-mail.org/request/domains/format/json/'))
         JSON.parse(response.body, symbolize_names: true)
       end
 
       def incoming_emails(email)
         hash = Digest::MD5.hexdigest(email)
-        response = Net::HTTP.get_response(URI("http://api.temp-mail.ru/request/mail/id/#{hash}/format/json/"))
+        response = Net::HTTP.get_response(URI("https://api.temp-mail.org/request/mail/id/#{hash}/format/json/"))
 
         if response.is_a?(Net::HTTPNotFound)
           []

--- a/spec/temp/mail/client_spec.rb
+++ b/spec/temp/mail/client_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'net/smtp'
+require 'gmail'
 
 describe Temp::Mail::Client do
   context 'get available domains' do
@@ -19,27 +20,19 @@ describe Temp::Mail::Client do
   context 'check incoming emails' do
     let(:message_subject) { 'test message' }
     let(:message) { 'This is a test message.' }
-    let(:from_email) { 'temp-mail-gem@yandex.ru' }
-    let(:to_email) { 'test-mail-gem@landmail.co' }
-
-    let(:smtp_host) { %w{smtp yandex ru}.join(?.) }
-    let(:smtp_port) { 465 }
-    let(:username) { 'temp-mail-gem' }
-    let(:password) { 'xei9daeph0Eka5Nileuh' }
+    let(:from_email) { 'tempmail.gem@gmail.com' }
+    let(:to_email) { "test#{described_class.new.available_domains[0]}" }
+    let(:user_name) { from_email }
+    let(:password) { 'd3liv3rusfr0m3v1l' }    
 
     before do
-      smtp = Net::SMTP.new(smtp_host, smtp_port)
-      smtp.enable_ssl
-      smtp.start('yandex.ru', username, password, :login) do
-        smtp.open_message_stream(from_email, to_email) do |f|
-          f.puts "From: #{from_email}"
-          f.puts "To: #{to_email}"
-          f.puts "Subject: #{message_subject}"
-          f.puts
-          f.puts message
-        end
-      end
-
+      gmail = Gmail.connect(user_name, password)
+      email = gmail.compose      
+      email.to = to_email
+      email.subject = message_subject
+      email.body = message
+      email.deliver!
+      gmail.logout
       sleep 2
     end
 
@@ -48,7 +41,7 @@ describe Temp::Mail::Client do
     it do
       expect(subject).to be_a Array
       expect(subject).to_not be_empty
-      expect(subject.last).to include(:mail_unique_id, :mail_id, :mail_address_id, :mail_from, :mail_subject, :mail_preview, :mail_text_only, :mail_text, :mail_html, :mail_timestamp)
+      expect(subject.last).to include(:createdAt, :mail_id, :mail_address_id, :mail_from, :mail_subject, :mail_preview, :mail_text_only, :mail_text, :mail_html, :mail_timestamp, :_id)      
       expect(subject.last).to include(mail_address_id: Digest::MD5.hexdigest(to_email))
       expect(subject.last).to include(mail_from: from_email)
       expect(subject.last).to include(mail_subject: message_subject)

--- a/temp-mail.gemspec
+++ b/temp-mail.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
+  spec.add_development_dependency 'gmail', '~> 0.6.0'
 end


### PR DESCRIPTION
- Change tempmail URL to https://api.temp-mail.org
- Change spec by updating smtp to gmail

Mr @maxd please review again